### PR TITLE
Change "To The" text color from orange to white in hero

### DIFF
--- a/builder-orbit-home-main/client/pages/Index.tsx
+++ b/builder-orbit-home-main/client/pages/Index.tsx
@@ -119,7 +119,7 @@ export default function Index() {
         <div className="container mx-auto px-8 lg:px-16 max-w-6xl">
           <div className="max-w-2xl">
             <h1 className="text-white text-5xl lg:text-6xl font-bold leading-tight mb-6">
-              Welcome <span className="text-energy-orange">To The</span>
+              Welcome <span className="text-white">To The</span>
               <br />
               Super Energy ltd.
             </h1>


### PR DESCRIPTION
## Purpose
Based on the conversation history, this change appears to be a visual adjustment to improve the styling and appearance of the hero section text on the main page.

## Code changes
- Updated the text color class for "To The" span in the hero heading from `text-energy-orange` to `text-white`
- This change affects the main heading in the Index.tsx page at line 122
- The text "To The" will now display in white instead of the previous orange color, maintaining consistency with the rest of the heading text

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5230dd83dbe84f6a8ae874e0cb7e4a01/pixel-haven)

👀 [Preview Link](https://5230dd83dbe84f6a8ae874e0cb7e4a01-pixel-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5230dd83dbe84f6a8ae874e0cb7e4a01</projectId>-->
<!--<branchName>pixel-haven</branchName>-->