### PR TITLE
Fix service cards overlay positioning on large screens

### DIFF
--- a/builder-orbit-home-main/client/pages/Index.tsx
+++ b/builder-orbit-home-main/client/pages/Index.tsx
@@ -292,7 +292,7 @@ export default function Index() {
         </div>
 
         {/* Service Cards Overlay - Integrated Part of Hero Group */}
-        <div className="service-cards-overlay absolute top-[518px] left-[3px] sm:top-[420px] sm:left-1/2 sm:transform sm:-translate-x-1/2 md:top-[460px] lg:top-[500px] lg:left-[591px] lg:transform-none xl:top-[580px] 2xl:top-[650px] max-lg:!top-[542px] w-full max-w-7xl px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 2xl:px-20">
+        <div className="service-cards-overlay absolute top-[518px] left-[3px] sm:top-[420px] sm:left-1/2 sm:transform sm:-translate-x-1/2 md:top-[460px] lg:top-[500px] lg:left-0 lg:transform-none xl:top-[580px] 2xl:top-[650px] max-lg:!top-[542px] w-full max-w-7xl px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 2xl:px-20">
           <div className="service-carousel-container relative">
             {/* Service Carousel */}
             <div


### PR DESCRIPTION
## Purpose
Based on the conversation context, this change addresses visual positioning issues with the service cards overlay component on the home page, specifically targeting layout improvements for better visual alignment.

## Code changes
- Updated the service cards overlay positioning in `Index.tsx`
- Changed `lg:left-[591px]` to `lg:left-0` in the className for the service-cards-overlay div
- This adjustment aligns the overlay to the left edge on large screens instead of using a fixed pixel offset
- Maintains existing responsive behavior for other screen sizes (sm, md, xl, 2xl breakpoints)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bda357ac0fd44ccf8bf55ea547a12657/swoosh-realm)

👀 [Preview Link](https://bda357ac0fd44ccf8bf55ea547a12657-swoosh-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bda357ac0fd44ccf8bf55ea547a12657</projectId>-->
<!--<branchName>swoosh-realm</branchName>-->