### PR TITLE
Adjust service cards overlay position for lg screens

### DIFF
--- a/builder-orbit-home-main/client/pages/Index.tsx
+++ b/builder-orbit-home-main/client/pages/Index.tsx
@@ -292,7 +292,7 @@ export default function Index() {
         </div>
 
         {/* Service Cards Overlay - Integrated Part of Hero Group */}
-        <div className="service-cards-overlay absolute top-[518px] left-[3px] sm:top-[420px] sm:left-1/2 sm:transform sm:-translate-x-1/2 md:top-[460px] lg:top-[500px] lg:left-0 lg:transform-none xl:top-[580px] 2xl:top-[650px] max-lg:!top-[542px] w-full max-w-7xl px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 2xl:px-20">
+        <div className="service-cards-overlay absolute top-[518px] left-[3px] sm:top-[420px] sm:left-1/2 sm:transform sm:-translate-x-1/2 md:top-[460px] lg:top-[501px] lg:left-0 lg:transform-none xl:top-[580px] 2xl:top-[650px] max-lg:!top-[542px] w-full max-w-7xl px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 2xl:px-20">
           <div className="service-carousel-container relative">
             {/* Service Carousel */}
             <div


### PR DESCRIPTION
## Purpose
Based on the conversation context, this change appears to be a visual adjustment to improve the positioning of service cards overlay on the home page for better layout alignment.

## Code changes
- Updated the `top` positioning value for large screens (`lg:`) from `500px` to `501px` in the service cards overlay component
- This is a minor 1-pixel adjustment to the vertical positioning of the service cards overlay element on large screen breakpoints
- The change affects the absolute positioning in the Index.tsx page component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bda357ac0fd44ccf8bf55ea547a12657/zen-hub)

👀 [Preview Link](https://bda357ac0fd44ccf8bf55ea547a12657-zen-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bda357ac0fd44ccf8bf55ea547a12657</projectId>-->
<!--<branchName>zen-hub</branchName>-->