### PR TITLE
Adjust spacing between hero and service sections

### DIFF
--- a/builder-orbit-home-main/client/pages/Index.tsx
+++ b/builder-orbit-home-main/client/pages/Index.tsx
@@ -441,7 +441,7 @@ export default function Index() {
       </section>
 
       {/* Projects Section */}
-      <section id="projects" className="py-12 sm:py-16 bg-energy-dark">
+      <section id="projects" className="py-12 sm:py-16 bg-energy-dark" style={{ marginTop: "-98px" }}>
         <div className="container mx-auto px-4 sm:px-8 lg:px-16 max-w-6xl">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-8 sm:mb-12 gap-4">
             <div className="flex items-center">


### PR DESCRIPTION
## Purpose
The user wanted to reduce the spacing between the hero section and service cards to create a more compact layout. Through multiple iterations, they requested progressively smaller gaps until the service cards would "enter halfway through" and "touch the hero section" for better visual integration.

## Code changes
- Added negative top margin (-60px) to hero content container
- Repositioned hero pagination dots with reduced bottom spacing and fixed top position
- Applied negative top margin (-100px) to service carousel for closer positioning to hero
- Added negative top margin (-98px) to projects section
- Adjusted service section container margins and positioning

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bda357ac0fd44ccf8bf55ea547a12657/neon-world)

👀 [Preview Link](https://bda357ac0fd44ccf8bf55ea547a12657-neon-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bda357ac0fd44ccf8bf55ea547a12657</projectId>-->
<!--<branchName>neon-world</branchName>-->